### PR TITLE
Support full doc comment text when generating markdown filename

### DIFF
--- a/src/site/forgus/plugins/apigenerator/ApiGenerateAction.java
+++ b/src/site/forgus/plugins/apigenerator/ApiGenerateAction.java
@@ -942,10 +942,18 @@ public class ApiGenerateAction extends AnAction {
         if (!config.getState().cnFileName) {
             return methodInfo.getMethodName();
         }
-        if (StringUtils.isEmpty(methodInfo.getDesc()) || !methodInfo.getDesc().contains(" ")) {
+        if (StringUtils.isEmpty(methodInfo.getDesc())) {
             return methodInfo.getMethodName();
         }
-        return methodInfo.getDesc().split(" ")[0];
+        String description = methodInfo.getDesc().trim();
+        if (StringUtils.isEmpty(description)) {
+            return methodInfo.getMethodName();
+        }
+        String fileName = description.replaceAll("[\\\\/:*?\"<>|]", "_");
+        if (StringUtils.isEmpty(fileName)) {
+            return methodInfo.getMethodName();
+        }
+        return fileName;
     }
 
     private void writeFieldInfo(Writer writer, FieldInfo info) throws IOException {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update markdown filename generation to use the full method doc description instead of only the first token
- sanitize invalid filesystem characters (`\\ / : * ? " < > |`) to `_` before creating markdown files
- keep fallback behavior: if doc description is empty after trim/sanitize, use the method name

## Why
When `Extract filename from doc comments` is enabled, descriptions like `Aba 掃碼後確認到帳` were previously truncated to `Aba`. This change preserves the full intended title as the generated filename.

## Validation
- verified code diff and fallback logic
- branch pushed successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02cca163-914e-402f-b743-47ce8b53e6c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02cca163-914e-402f-b743-47ce8b53e6c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

